### PR TITLE
feat: rearchitect renderer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use glutin::{
     platform::run_return::EventLoopExtRunReturn,
 };
 use webrender::api::units::DeviceIntSize;
-use window::{RendererEvent, Window};
+use window::{RendererEvent, Window, UIEvent, TaskEvent};
 
 mod render;
 mod state;
@@ -28,14 +28,14 @@ pub fn launch(root: Component<()>) {
         let size = window.inner_size();
 
         match event {
-            Event::UserEvent(RendererEvent::Dirty(w)) if &w == id => {
+            Event::UserEvent(RendererEvent::UIEvent(UIEvent::Dirty(w))) if &w == id => {
                 let device_size = DeviceIntSize::new(size.width as i32, size.height as i32);
                 let device_pixel_ratio = window.scale_factor() as f32;
                 let layout_size =
                     device_size.to_f32() / webrender::euclid::Scale::new(device_pixel_ratio);
-                context.send_event(Event::UserEvent(RendererEvent::Redraw(w, layout_size)));
+                context.send_event(Event::UserEvent(RendererEvent::TaskEvent(TaskEvent::Redraw(w, layout_size))));
             }
-            Event::UserEvent(RendererEvent::Rerender(w)) if &w == id => {
+            Event::UserEvent(RendererEvent::UIEvent(UIEvent::Rerender(w))) if &w == id => {
                 let device_size = DeviceIntSize::new(size.width as i32, size.height as i32);
                 context.rerender(device_size);
                 context.swap_buffers().ok();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,12 @@ extern crate log;
 
 use dioxus::prelude::Component;
 use glutin::{
+    event::Event,
     event_loop::{ControlFlow, EventLoop},
     platform::run_return::EventLoopExtRunReturn,
 };
-use window::Window;
+use webrender::api::units::DeviceIntSize;
+use window::{RendererEvent, Window};
 
 mod render;
 mod state;
@@ -17,15 +19,30 @@ pub fn launch(root: Component<()>) {
     // env_logger::init();
 
     let mut event_loop = EventLoop::with_user_event();
-    let window = Window::new(root, &event_loop);
-
-    event_loop.run_return(move |event, _, control_flow| {
+    let mut context = Window::new(root, &event_loop);
+    event_loop.run_return(|event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
 
-        match event {
-            _ => (),
-        }
+        let id = context.id();
+        let window = context.window();
+        let size = window.inner_size();
 
-        window.send_event(event);
+        match event {
+            Event::UserEvent(RendererEvent::Dirty(w)) if &w == id => {
+                let device_size = DeviceIntSize::new(size.width as i32, size.height as i32);
+                let device_pixel_ratio = window.scale_factor() as f32;
+                let layout_size =
+                    device_size.to_f32() / webrender::euclid::Scale::new(device_pixel_ratio);
+                context.send_event(Event::UserEvent(RendererEvent::Redraw(w, layout_size)));
+            }
+            Event::UserEvent(RendererEvent::Rerender(w)) if &w == id => {
+                let device_size = DeviceIntSize::new(size.width as i32, size.height as i32);
+                context.rerender(device_size);
+                context.swap_buffers().ok();
+            }
+            _ => context.send_event(event),
+        }
     });
+
+    context.deinit();
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,11 +1,13 @@
 use webrender::{
-    api::{units::LayoutSize, *},
+    api::{
+        units::{LayoutPoint, LayoutRect, LayoutSize},
+        *,
+    },
     RenderApi, Transaction,
 };
 
-use crate::utils::RectBuilder;
-
 pub fn render(
+    builder: &mut DisplayListBuilder,
     pipeline_id: PipelineId,
     document_id: DocumentId,
     epoch: Epoch,
@@ -13,7 +15,6 @@ pub fn render(
     layout_size: LayoutSize,
 ) {
     let mut txn = Transaction::new();
-    let mut builder = DisplayListBuilder::new(pipeline_id);
     builder.begin();
 
     {
@@ -28,10 +29,36 @@ pub fn render(
             PrimitiveFlags::IS_BACKFACE_VISIBLE,
         );
 
+        let clip_chain_id = builder.define_clip_chain(None, []);
+
+        builder.push_rect(
+            &CommonItemProperties::new(
+                LayoutRect::from_origin_and_size(
+                    LayoutPoint::new(300 as f32, 300 as f32),
+                    LayoutSize::new(100 as f32, 100 as f32),
+                ),
+                SpaceAndClipInfo {
+                    spatial_id,
+                    clip_chain_id,
+                },
+            ),
+            LayoutRect::from_origin_and_size(
+                LayoutPoint::new(100 as f32, 100 as f32),
+                LayoutSize::new(500 as f32, 500 as f32),
+            ),
+            ColorF::new(0.0, 1.0, 1.0, 1.0),
+        );
+
         builder.pop_stacking_context();
     }
 
-    txn.set_display_list(epoch, None, layout_size, builder.end());
+    txn.set_display_list(
+        epoch,
+        Some(ColorF::new(0., 0., 0., 1.0)),
+        layout_size,
+        builder.end(),
+    );
+    txn.set_root_pipeline(pipeline_id);
     txn.generate_frame(0, RenderReasons::empty());
     api.send_transaction(document_id, txn);
 }


### PR DESCRIPTION
I rearchitected render process.
`create_webrender_instance` can not be invoked without main thread, so this occurs error on may macOS.
So I constructed multi threading that handle actual render in main thread, and handle making display list in another thread.
I think traversing vdom and making display list is heavy task so we need to move these task another thread.

This is prototype so you can feel free to close this PR if not intended.